### PR TITLE
Feature: filter all scheduled dids for a device

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -210,11 +210,11 @@ Die **e3oncan Datenpunkte**-Seite ist die zentrale Stelle zum Durchsuchen von Da
 
 Alle Geräte und erkannte Energiezähler werden als aufklappbare Karten angezeigt, standardmäßig zugeklappt für einen schnellen Überblick über das gesamte System. Ein Klick auf den Karten-Header klappt die Karte auf. Das Suchfeld filtert nach Name oder ID, passende Karten werden automatisch ausgeklappt.
 
-Wenn für ein Gerät noch kein Datenpunktscan durchgeführt wurde, erscheint oben auf der Seite ein Warnbanner als Erinnerung.
+Wenn für ein Gerät noch kein Datenpunktscan durchgeführt wurde, erscheint oben auf der Seite ein Warnbanner als Erinnerung. Wenn ein Scan vorhanden ist, die in v1.x eingeführte Collect-Auto-Erkennung aber noch nicht ausgeführt wurde, empfiehlt ein Info-Banner einen erneuten Scan. Dieser Hinweis kann per Instanz dauerhaft ausgeblendet werden (Schaltfläche **Nicht mehr anzeigen**).
 
 **Gerätekarten**
 
-Jede Gerätekarte listet ihre Datenpunkte mit ID, Name, Codec und Zeitplaneinstellungen auf. Der Collect-Schalter und die minimale Aktualisierungszeit erscheinen im Karten-Header. Wenn während des Datenpunktscans Collect-Traffic vom Gerät erkannt wurde, wird im Karten-Header ein grünes Pin-Symbol als Bestätigung angezeigt.
+Jede Gerätekarte listet ihre Datenpunkte mit ID, Name, Codec und Zeitplaneinstellungen auf. Der Collect-Schalter und die minimale Aktualisierungszeit erscheinen im Karten-Header. Wenn während des Datenpunktscans Collect-Traffic vom Gerät erkannt wurde, wird im Karten-Header ein grünes Pin-Symbol als Bestätigung angezeigt. Sind Datenpunkte eingeplant, erscheint ein grünes **N scheduled**-Badge — ein Klick darauf klappt die Karte auf und zeigt nur die eingeplanten Datenpunkte. Nochmaliger Klick auf das Badge hebt den Filter auf; ein Klick auf den Karten-Header hebt den Filter auf und klappt die Karte ein oder vollständig auf, je nachdem, ob das Badge sie geöffnet hatte.
 
 **Energiezähler-Karten**
 
@@ -376,51 +376,10 @@ Ja. Den State `e3oncan.0.<GERÄT>.cmnd.udsReadByDid` bearbeiten und eine Liste v
 Wenn Ihnen dieses Projekt gefällt — oder Sie einfach großzügig sind — würde ich mich über ein Bier freuen. Prost! :beers:
 
 ## Changelog
-<!--
-    Placeholder for the next version (at the beginning of the line):
-    ### **WORK IN PROGRESS**
--->
-### **WORK IN PROGRESS**
-* (MyHomeMyData) Behoben: Beim Speichern von Schedules in der Datenpunkte-Seite konnten unter bestimmten Umständen veraltete Einträge verbleiben
-* (MyHomeMyData) Topology-Schaltfläche in der Datenpunkte-Seite ergänzt; öffnet das Bus-Topologie-Diagramm in einem modalen Dialog
-* (MyHomeMyData) Scan-Status-Erkennung verbessert: nutzt `udsDidsWritable` statt `didsMetaDict`, um zuverlässig zu erkennen, ob ein Datenpunktscan durchgeführt wurde
-* (MyHomeMyData) Hinweis auf erneuten Scan in der Datenpunkte-Seite ergänzt, wenn ein Scan vorhanden, aber die Collect-Erkennung noch nicht durchgeführt wurde
 
-### 1.0.0-beta.1 (2026-04-30)
-* (MyHomeMyData) Bus-Topologie-Analyse wird jetzt automatisch nach dem Datenpunktscan erstellt; Ergebnisse werden in `info.topology` (JSON) und `info.topologyHtml` (HTML) gespeichert; Details im Readme
-* (MyHomeMyData) Eingabevalidierung für Intervall- und Verzögerungsfelder in der Datenpunkte-Seite ergänzt — nur positive ganze Zahlen werden akzeptiert
+### Historie der Änderungen
 
-### 1.0.0-beta.0 (2026-04-26)
-* (MyHomeMyData) Neue e3oncan Datenpunkte-Webseite, direkt in der Adapterinstanzzeile verankert
-* (MyHomeMyData) Energiezähler (E380, E3100CB) werden jetzt während des Gerätescans durch passives CAN-Lauschen auf beiden Kanälen automatisch erkannt
-* (MyHomeMyData) State-Namen für Energiezähler werden automatisch anhand von CAN-Adresse und Kanal vergeben; Details im Readme
-* (MyHomeMyData) Collect-Schalter und Verzögerung für Energiezähler werden ausschließlich in der e3oncan Datenpunkte-Seite konfiguriert; Änderungen werden nach Adapter-Neustart wirksam
-* (MyHomeMyData) Beim ersten Start nach einem Upgrade wird die Aktiv-Einstellung automatisch aus der bisherigen Adapterkonfiguration migriert
-* (MyHomeMyData) Collect-fähige Geräte werden jetzt während des Datenpunktscans durch passives CAN-Lauschen automatisch erkannt; ein Pin-Symbol wird im Gerätekarten-Header für jedes erkannte Gerät angezeigt
-* (MyHomeMyData) Option hinzugefügt, das Speichern von Datenpunktwerten während des Datenpunktscans zu unterdrücken
-
-### 0.11.1 (2026-04-23)
-* (MyHomeMyData) Robustheit verbessert: Ein Datenpunkt der Länge null wird als „negative response" behandelt
-* (MyHomeMyData) Metadaten werden jetzt auch nach dem Löschen eines Datenpunkts wiederhergestellt
-* (MyHomeMyData) Testfälle für deutsche Systemsprache angepasst
-
-### 0.11.0 (2026-04-14)
-* (MyHomeMyData) Für volle Unterstützung von Varianten-Datenpunkten und Metadaten bitte einen Gerätescan gefolgt von einem Datenpunktscan durchführen
-* (MyHomeMyData) Unterstützung für Varianten-Datenpunkte und Geräte-Datenformatkonfiguration hinzugefügt; Details unter https://github.com/MyHomeMyData/ioBroker.e3oncan/lib/data-points.md
-* (MyHomeMyData) Metadaten zu mehreren Datenpunkten hinzugefügt, z. B. Beschreibung, Einheit, Link zu weiteren Infos
-* (MyHomeMyData) Beim Datenpunktscan werden jetzt Metadaten zu den Datenpunkt-Objekten hinzugefügt
-* (MyHomeMyData) Handhabung schreibbarer Datenpunkte geändert; diese Information ist jetzt auch in der Datenpunktdefinition verfügbar; die Handhabung der Whitelist für Schreibzugriffe ist unverändert
-* (MyHomeMyData) Beim Gerätescan werden die verwendeten Datenformate (Datenpunkt 382) ausgewertet
-* (MyHomeMyData) Struktur vieler Datenpunkte aktualisiert; Details im [Changelog](lib/data-points.md#changelog-of-data-point-definitions)
-
-### 0.10.14 (2025-11-03)
-* (MyHomeMyData) Elemente zu enums.js basierend auf PR Nr. 182 von open3e hinzugefügt
-* (MyHomeMyData) Konfiguration der Dids-Scan-Grenzen im Quellcode vereinfacht
-* (MyHomeMyData) Scan bis Did 3338 erweitert
-* (MyHomeMyData) Hinweis zum Scanbereich im Readme ergänzt
-* (MyHomeMyData) Korrekturen für Issue #169 (Repository Checker)
-* (MyHomeMyData) Bugfix: Manuelle Änderung gerätespezifischer Dids wurde für Collect-Worker nicht ausgewertet
-* (MyHomeMyData) Liste der Datenpunkte für E3-Geräte auf Version 20251102 aktualisiert
+Die Changelog-Einträge sind in der englischen Verison der (README.MD)[README.MD#changelog] verfügbar.
 
 ### Ältere Versionen
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ If you enjoyed this project — or just feeling generous, consider buying me a b
 -->
 ### **WORK IN PROGRESS**
 * (MyHomeMyData) Clicking the green scheduled badge on a device card filters the view to show only its scheduled data points; clicking the badge again or the card header restores the full view
+* (MyHomeMyData) Fixed: saving from the datapoints tab now preserves inactive schedules (disabled in the old config UI) for full backward compatibility
 
 ### 1.0.0 (2026-05-06)
 * (MyHomeMyData) Adapter requires node.js >= 22 now

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ The **e3oncan datapoints** page is the primary place for browsing data points an
 
 All devices and any detected energy meters are shown as expandable cards, starting collapsed so you get an overview of your whole system at a glance. Click a card header to expand it. The search box filters by name or ID, and matching cards are expanded automatically.
 
-If a data point scan has not been performed yet for a device, a warning banner is shown at the top of the page as a reminder.
+If a data point scan has not been performed yet for a device, a warning banner is shown at the top of the page as a reminder. If a scan has been done but the Collect auto-detection introduced in v1.x has not yet run, an info banner recommends running a new data point scan. This hint can be permanently dismissed per instance with the **Don't show again** button.
 
 **Device cards**
 
-Each device card lists its data points with ID, name, codec, and schedule settings. The Collect toggle and min. update time appear in the card header. If Collect traffic from the device was detected during the data point scan, a green pin icon is shown in the card header as a confirmation.
+Each device card lists its data points with ID, name, codec, and schedule settings. The Collect toggle and min. update time appear in the card header. If Collect traffic from the device was detected during the data point scan, a green pin icon is shown in the card header as a confirmation. If any data points are scheduled, a green **N scheduled** badge appears — click it to expand the card and show only the scheduled data points. Click the badge again to remove the filter; clicking the card header removes the filter and collapses or fully expands the card, depending on whether the badge had opened it.
 
 **Energy meter cards**
 
@@ -399,6 +399,11 @@ If you enjoyed this project — or just feeling generous, consider buying me a b
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+* (MyHomeMyData) Fixed: re-scan hint was incorrectly shown when a v1.x scan had been performed but found no Collect-capable devices
+* (MyHomeMyData) Re-scan hint can now be permanently dismissed per instance via a "Don't show again" button
+* (MyHomeMyData) Clicking the green scheduled badge on a device card filters the view to show only its scheduled data points; clicking the badge again or the card header restores the full view
+
 ### 1.0.0 (2026-05-06)
 * (MyHomeMyData) Adapter requires node.js >= 22 now
 * (MyHomeMyData) Improved scan status detection: uses `udsDidsWritable` instead of `didsMetaDict` to reliably detect whether a data point scan has been performed

--- a/README.md
+++ b/README.md
@@ -400,8 +400,6 @@ If you enjoyed this project — or just feeling generous, consider buying me a b
     ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
-* (MyHomeMyData) Fixed: re-scan hint was incorrectly shown when a v1.x scan had been performed but found no Collect-capable devices
-* (MyHomeMyData) Re-scan hint can now be permanently dismissed per instance via a "Don't show again" button
 * (MyHomeMyData) Clicking the green scheduled badge on a device card filters the view to show only its scheduled data points; clicking the badge again or the card header restores the full view
 
 ### 1.0.0 (2026-05-06)

--- a/admin/tab.html
+++ b/admin/tab.html
@@ -559,7 +559,10 @@
 
             const tabDevAddrs = new Set(allDevices.map(function(d) { return Number(d.devAddr); }));
             const newSchedules = (adapterNative.tableUdsSchedules || []).filter(function(s) {
-                return !tabDevAddrs.has(Number(s.udsSelectDevAddr));
+                // Keep schedules for devices not managed by this tab, and keep
+                // inactive schedules for tab devices (backward compatibility with
+                // the old config UI that allows disabling a schedule without deleting it).
+                return !tabDevAddrs.has(Number(s.udsSelectDevAddr)) || !s.udsScheduleActive;
             });
             const newCollectExt = JSON.parse(JSON.stringify(adapterNative.tableCollectCanExt || []));
             const newCollectInt = JSON.parse(JSON.stringify(adapterNative.tableCollectCanInt || []));

--- a/admin/tab.html
+++ b/admin/tab.html
@@ -125,6 +125,8 @@
         let sock = null;
         let loadedEnergyMeters = {};
         let topologyHtml = '';
+        let scheduledFilter = null;
+        let filterWasCollapsed = false;
 
         document.getElementById('btn-dismiss-rescan-hint').addEventListener('click', function() {
             localStorage.setItem('rescanHintDismissed_' + namespace, '1');
@@ -317,7 +319,7 @@
                     '<div class="dev-name-col"><strong>' + dev.devStateName + '</strong>' +
                     '<code class="ms-2 small">' + dev.devAddr + '</code>' +
                     '<span class="badge bg-secondary ms-2">' + dev.dids.length + ' DIDs</span>' +
-                    (activeCount > 0 ? '<span class="badge bg-success ms-1 scheduled-badge">' + activeCount + ' scheduled</span>' : '') +
+                    (activeCount > 0 ? '<span class="badge ' + (scheduledFilter === dev.devStateName ? 'bg-primary' : 'bg-success') + ' ms-1 scheduled-badge" style="cursor:pointer" onclick="event.stopPropagation();toggleScheduledFilter(\'' + dev.devStateName.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + '\')">' + activeCount + ' scheduled</span>' : '') +
                     '</div>' +
                     collectHtml +
                     '</div>' +
@@ -338,7 +340,17 @@
                 const chevron = card.querySelector('.bi-chevron-down');
                 card.querySelector('.card-header').addEventListener('click', function(e) {
                     if (e.target.closest('.collect-area')) return;
-                    bootstrap.Collapse.getOrCreateInstance(collapseEl).toggle();
+                    if (scheduledFilter === dev.devStateName) {
+                        scheduledFilter = null;
+                        const badge = card.querySelector('.scheduled-badge');
+                        if (badge) { badge.classList.remove('bg-primary'); badge.classList.add('bg-success'); }
+                        if (!filterWasCollapsed) {
+                            bootstrap.Collapse.getOrCreateInstance(collapseEl).hide();
+                        }
+                        filterRows();
+                    } else {
+                        bootstrap.Collapse.getOrCreateInstance(collapseEl).toggle();
+                    }
                 });
                 chevron.style.transform = 'rotate(-90deg)';
                 collapseEl.addEventListener('hide.bs.collapse', function() { chevron.style.transform = 'rotate(-90deg)'; });
@@ -398,9 +410,13 @@
             const schedMode = document.querySelector('input[name="schedFilter"]:checked').value;
             const ivStr = document.getElementById('filter-interval-val').value.trim();
             const ivFilter = (schedMode === 'interval' && ivStr) ? parseInt(ivStr, 10) : null;
-            const hasActiveFilter = search || schedMode !== 'all';
+            const hasActiveFilter = search || schedMode !== 'all' || scheduledFilter;
 
             document.querySelectorAll('.ecu-group').forEach(function(group) {
+                if (scheduledFilter && group.dataset.devStateName !== scheduledFilter) {
+                    group.style.display = 'none';
+                    return;
+                }
                 let visibleCount = 0;
                 group.querySelectorAll('tbody tr').forEach(function(row) {
                     const textOk = !search ||
@@ -408,7 +424,11 @@
                         (row.dataset.name || '').includes(search) ||
                         (row.dataset.desc || '').includes(search);
                     let schedOk = true;
-                    if (schedMode === 'onstart') {
+                    if (scheduledFilter) {
+                        const onstart = row.querySelector('.onstart-check').checked;
+                        const iv = row.querySelector('.interval-input').value.trim();
+                        schedOk = onstart || iv !== '';
+                    } else if (schedMode === 'onstart') {
                         schedOk = row.querySelector('.onstart-check').checked;
                     } else if (schedMode === 'interval') {
                         const iv = row.querySelector('.interval-input').value.trim();
@@ -439,6 +459,34 @@
             });
         }
 
+        function toggleScheduledFilter(devStateName) {
+            let group = null;
+            document.querySelectorAll('.ecu-group').forEach(function(g) {
+                if (g.dataset.devStateName === devStateName) group = g;
+            });
+            const collapseEl = group ? group.querySelector('.collapse') : null;
+
+            if (scheduledFilter === devStateName) {
+                scheduledFilter = null;
+                if (filterWasCollapsed && collapseEl) {
+                    bootstrap.Collapse.getOrCreateInstance(collapseEl).hide();
+                }
+            } else {
+                filterWasCollapsed = collapseEl ? !collapseEl.classList.contains('show') : false;
+                scheduledFilter = devStateName;
+                if (collapseEl) bootstrap.Collapse.getOrCreateInstance(collapseEl).show();
+            }
+
+            document.querySelectorAll('.ecu-group').forEach(function(g) {
+                const badge = g.querySelector('.scheduled-badge');
+                if (!badge) return;
+                const isActive = scheduledFilter && g.dataset.devStateName === scheduledFilter;
+                badge.classList.toggle('bg-success', !isActive);
+                badge.classList.toggle('bg-primary', !!isActive);
+            });
+            filterRows();
+        }
+
         function markChanged() {
             hasChanges = true;
             document.getElementById('btn-save').disabled = false;
@@ -462,6 +510,8 @@
                 if (!badge) {
                     badge = document.createElement('span');
                     badge.className = 'badge bg-success ms-1 scheduled-badge';
+                    badge.style.cursor = 'pointer';
+                    badge.onclick = (function(name) { return function(e) { e.stopPropagation(); toggleScheduledFilter(name); }; })(card.dataset.devStateName);
                     nameCol.appendChild(badge);
                 }
                 badge.textContent = count + ' scheduled';


### PR DESCRIPTION
* Clicking the green scheduled badge on a device card filters the view to show only its scheduled data points; clicking the badge again or the card header restores the full view
* Preserve inactive schedules on save for backward compatibility